### PR TITLE
Default date should set to the correct date

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -51,13 +51,12 @@ public class AddCommandParser implements Parser<AddCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Flag flag = ParserUtil.parseFlag(argMultimap.getValue(PREFIX_FLAG).orElse("false"));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        // TODO: tempory orElse() fix
         PrevDateMet prevDateMet = ParserUtil.parsePrevDateMet(argMultimap.getValue(PREFIX_PREV_DATE_MET)
-                .orElse("2022-03-14"));
-        Info info = ParserUtil.parseInfo(argMultimap.getValue(PREFIX_INFO).orElse(""));
+                .orElse(PrevDateMet.getTodaysDate()));
+        Info info = ParserUtil.parseInfo(argMultimap.getValue(PREFIX_INFO)
+                .orElse("No further info"));
 
         Person person = new Person(name, phone, email, address, flag, tagList, prevDateMet, info);
-
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/model/person/PrevDateMet.java
+++ b/src/main/java/seedu/address/model/person/PrevDateMet.java
@@ -35,6 +35,16 @@ public class PrevDateMet {
         //return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Method to get today's date in the event where user does not
+     * specify the date last met when adding a client.
+     *
+     * @return String representation of today's date in YYYY-MM-DD format.
+     */
+    public static String getTodaysDate() {
+        return LocalDate.now().toString();
+    }
+
     @Override
     public String toString() {
         return value.toString();


### PR DESCRIPTION
Default date is set to 2022-03-14 as a temporary fix

Default date of previous date met should be set to date of when
the client is being added into HustleBook. Default value of info
of an empty string can be counterintuitive when displayed in the
HustleBook.

Let's,
* change the default value of date to the current date of adding
client.
* change the default value of info to No further info.

This should close #57.