### PR TITLE
Modify delete command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -163,24 +163,12 @@ Examples:
 
 Deletes the specified person from the HustleBook.
 
-* Using **Index**:
+Format: `delete NAME`
 
-  Format: `delete INDEX`
-
-  * Deletes the person at the specified `INDEX`.
-  * The index refers to the index number shown in the displayed person list.
-  * The index **must be a positive integer** 1, 2, 3, …​
+Deletes the person with the specified `NAME`.
   
-    Examples:
-    * `list` followed by `delete 2` deletes the 2nd person in the address book.
-    * `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
-    
-
-* Using **Name**: 
-
-  Format: `delete n/NAME`
-
-  * Deletes the person with the specified `NAME`.
+Examples: 
+* `delete John` deletes the person named `John` in the HustleBook.
 
 ### Clearing all entries : `clear`
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_NAME = "The person name provided in not in the list";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -32,6 +32,14 @@ public class Index {
     }
 
     /**
+     * Increments the index by the given specified value.
+     * @param value The value to be added to index value.
+     */
+    public void increment(int value) {
+        this.zeroBasedIndex += value;
+    }
+
+    /**
      * Creates a new {@code Index} using a zero-based index.
      */
     public static Index fromZeroBased(int zeroBasedIndex) {

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -6,8 +6,11 @@ import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 
 /**
@@ -18,25 +21,27 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + ": Deletes the person identified by their name in the displayed person list.\n"
+            + "Parameters: Name (Alphanumerical characters and spaces only)\n"
+            + "Example: " + COMMAND_WORD + " John Doe";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 
-    private final Index targetIndex;
+    private final Name targetName;
 
-    public DeleteCommand(Index targetIndex) {
-        this.targetIndex = targetIndex;
+    public DeleteCommand(Name targetName) {
+        this.targetName = targetName;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
+        AddressBook tempAddressBook = new AddressBook();
+        Index targetIndex = tempAddressBook.getPersonListIndex(lastShownList, targetName);
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
@@ -48,6 +53,6 @@ public class DeleteCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DeleteCommand // instanceof handles nulls
-                && targetIndex.equals(((DeleteCommand) other).targetIndex)); // state check
+                && targetName.equals(((DeleteCommand) other).targetName)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Name;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -18,8 +19,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            Name name = ParserUtil.parseName(args);
+            return new DeleteCommand(name);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -5,7 +5,10 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import javafx.collections.ObservableList;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.Flag;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -105,6 +108,26 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     //// util methods
+
+    /**
+     * Gives the index of the person with the given name if they exist.
+     * If person doesn't exist, final index value is saved as length of the list.
+     * @param personList A list of person objects stored in data.
+     * @param name The given name used as reference to find the person.
+     * @return An Index object holding the index of the person in the list.
+     */
+    public Index getPersonListIndex(List<Person> personList, Name name) {
+        Index result = Index.fromZeroBased(0);
+        String personName = name.fullName;
+        for (Person i : personList) {
+            String currName = i.getName().fullName;
+            if (StringUtil.containsWordIgnoreCase(currName, personName)) {
+                break;
+            }
+            result.increment(1);
+        }
+        return result;
+    }
 
     @Override
     public String toString() {

--- a/src/test/java/seedu/address/commons/core/index/IndexTest.java
+++ b/src/test/java/seedu/address/commons/core/index/IndexTest.java
@@ -38,6 +38,35 @@ public class IndexTest {
     }
 
     @Test
+    public void testIncrement() {
+        final int INCREMENT_VALUE = 2;
+        final Index zeroBased = Index.fromZeroBased(2);
+        final Index oneBased = Index.fromOneBased(2);
+        final Index zeroBasedHigh = Index.fromZeroBased(6);
+        final Index oneBasedHigh = Index.fromOneBased(6);
+
+        // check equality for zero based low value
+        zeroBased.increment(INCREMENT_VALUE);
+        assertEquals(4, zeroBased.getZeroBased());
+        assertEquals(5, zeroBased.getOneBased());
+
+        // check equality for zero based high value
+        zeroBasedHigh.increment(INCREMENT_VALUE);
+        assertEquals(8, zeroBasedHigh.getZeroBased());
+        assertEquals(9, zeroBasedHigh.getOneBased());
+
+        // check equality for one based low value
+        oneBased.increment(INCREMENT_VALUE);
+        assertEquals(3, oneBased.getZeroBased());
+        assertEquals(4, oneBased.getOneBased());
+
+        // check equality for one based high value
+        oneBasedHigh.increment(INCREMENT_VALUE);
+        assertEquals(7, oneBasedHigh.getZeroBased());
+        assertEquals(8, oneBasedHigh.getOneBased());
+    }
+
+    @Test
     public void equals() {
         final Index fifthPersonIndex = Index.fromOneBased(5);
 

--- a/src/test/java/seedu/address/commons/core/index/IndexTest.java
+++ b/src/test/java/seedu/address/commons/core/index/IndexTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import org.junit.jupiter.api.Test;
 
 public class IndexTest {
+    private static final int INCREMENT_VALUE = 2;
 
     @Test
     public void createOneBasedIndex() {
@@ -39,7 +40,6 @@ public class IndexTest {
 
     @Test
     public void testIncrement() {
-        final int INCREMENT_VALUE = 2;
         final Index zeroBased = Index.fromZeroBased(2);
         final Index oneBased = Index.fromOneBased(2);
         final Index zeroBasedHigh = Index.fromZeroBased(6);

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_NAME;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -60,8 +60,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        String deleteCommand = "delete ferrari";
+        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_NAME);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -6,13 +6,15 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalNames.FULL_NAME_FIRST_PERSON;
+import static seedu.address.testutil.TypicalNames.NAME_SECOND_PERSON;
+import static seedu.address.testutil.TypicalNames.NAME_INVALID_PERSON;
+import static seedu.address.testutil.TypicalNames.SHORT_NAME_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
-import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -27,9 +29,9 @@ public class DeleteCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_validIndexUnfilteredList_success() {
+    public void execute_validNameUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(SHORT_NAME_FIRST_PERSON);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
@@ -40,19 +42,18 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+    public void execute_invalidNameUnfilteredList_throwsCommandException() {
+        DeleteCommand deleteCommand = new DeleteCommand(NAME_INVALID_PERSON);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_NAME);
     }
 
     @Test
-    public void execute_validIndexFilteredList_success() {
+    public void execute_validNameFilteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(SHORT_NAME_FIRST_PERSON);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
@@ -64,28 +65,24 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
+    public void execute_invalidNameFilteredList_throwsCommandException() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+        DeleteCommand deleteCommand = new DeleteCommand(NAME_SECOND_PERSON);
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
-
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_NAME);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(FULL_NAME_FIRST_PERSON);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(NAME_SECOND_PERSON);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(FULL_NAME_FIRST_PERSON);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -7,8 +7,8 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalNames.FULL_NAME_FIRST_PERSON;
-import static seedu.address.testutil.TypicalNames.NAME_SECOND_PERSON;
 import static seedu.address.testutil.TypicalNames.NAME_INVALID_PERSON;
+import static seedu.address.testutil.TypicalNames.NAME_SECOND_PERSON;
 import static seedu.address.testutil.TypicalNames.SHORT_NAME_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalNames.FULL_NAME_FIRST_PERSON;
 
 import java.util.Arrays;
 import java.util.List;
@@ -49,8 +50,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+                DeleteCommand.COMMAND_WORD + " " + FULL_NAME_FIRST_PERSON);
+        assertEquals(new DeleteCommand(FULL_NAME_FIRST_PERSON), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalNames.FULL_NAME_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,11 +22,11 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "Alice Pauline", new DeleteCommand(FULL_NAME_FIRST_PERSON));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "!", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalNames.java
+++ b/src/test/java/seedu/address/testutil/TypicalNames.java
@@ -1,0 +1,13 @@
+package seedu.address.testutil;
+
+import seedu.address.model.person.Name;
+
+/**
+ * A utility class containing a list of {@code Name} objects to be used in tests.
+ */
+public class TypicalNames {
+    public static final Name FULL_NAME_FIRST_PERSON = new Name("Alice Pauline");
+    public static final Name SHORT_NAME_FIRST_PERSON = new Name("Alice");
+    public static final Name NAME_SECOND_PERSON = new Name("Benson");
+    public static final Name NAME_INVALID_PERSON = new Name("Ferrari");
+}


### PR DESCRIPTION
Delete Command: Modify to delete the person by name

Currently, the `delete` command uses the index to delete a person.

Due to the use of an index, `list` is utilized to get the correct index first.
This results in an additional command being used, making it less user-friendly and slow to type out both commands.

Let's,
* Modify the delete command to delete using the person's name
* Update test cases to cater for the change from index to name
* Update the User Guide to reflect the updated code usage

Closes #12 