### PR TITLE
Modify edit info parser

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -134,6 +134,7 @@ Edits an existing person in the HustleBook.
   * When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.
   * You can remove all the person’s tags by typing `t/` without
       specifying any tags after it.
+  * You can remove the person's info by typing `i/` without specifying any info after it.
 
     Examples:
     * `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -72,7 +72,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
         if (argMultimap.getValue(PREFIX_INFO).isPresent()) {
-            editPersonDescriptor.setInfo(ParserUtil.parseInfo(argMultimap.getValue(PREFIX_INFO).get()));
+            parseInfoForEdit(argMultimap, editPersonDescriptor);
         }
         if (argMultimap.getValue(PREFIX_PREV_DATE_MET).isPresent()) {
             editPersonDescriptor.setPrevDateMet(
@@ -83,6 +83,22 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
+    }
+
+    /**
+     * Helper function to parse info to check if it's updating new info or to clear info to set the default value.
+     *
+     * @param argMultimap ArgumentMultimap containing all the data to be edited.
+     * @param editPersonDescriptor EditPersonDescriptor to edit the person.
+     * @throws ParseException when info parsed is not valid.
+     */
+    private void parseInfoForEdit(ArgumentMultimap argMultimap,
+                                  EditPersonDescriptor editPersonDescriptor) throws ParseException {
+        String newInfo = argMultimap.getValue(PREFIX_INFO).get();
+        if (newInfo.isBlank()) {
+            newInfo = "No further info";
+        }
+        editPersonDescriptor.setInfo(ParserUtil.parseInfo(newInfo));
     }
 
     /**


### PR DESCRIPTION
Modify edit info parser

No way to clear info of client through edit to show the default
value of "No further info"

Let's 
* make changes to the info parser to allow user to key edit NAME
i/ where parameter is empty to clear the info - similar to clearing
tags.
* mention how to clear info in the User Guide under `edit` command.

Note: This change still should not allow i/ to be empty when adding
new person.

This should close #74.