### PR TITLE
Add cancel meeting through meet command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MeetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MeetCommand.java
@@ -23,7 +23,7 @@ public class MeetCommand extends Command {
             + "Parameters: NAME (must be found in HustleBook), DATE (YYYY-MM-DD format), TIME (24HR Format)\n"
             + "Example: " + COMMAND_WORD + " NAME" + " m/2022-02-23" + " t/1530";
 
-    public static final String MESSAGE_SCHEDULE_MEETING_PERSON_SUCCESS = "Scheduled a meeting: %1$s";
+    public static final String MESSAGE_SCHEDULE_MEETING_PERSON_SUCCESS = "Updated a meeting with %1$s";
 
     private final Name targetName;
     private final ScheduledMeeting scheduledMeeting;

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -17,5 +17,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_INFO = new Prefix("i/");
     public static final Prefix PREFIX_MEETING_DATE = new Prefix("d/");
     public static final Prefix PREFIX_MEETING_TIME = new Prefix("t/");
+    public static final Prefix PREFIX_CANCEL_MEETING = new Prefix("c/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/MeetCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MeetCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CANCEL_MEETING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MEETING_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MEETING_TIME;
 
@@ -26,9 +27,18 @@ public class MeetCommandParser implements Parser<MeetCommand> {
     public MeetCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_MEETING_DATE, PREFIX_MEETING_TIME);
+                ArgumentTokenizer.tokenize(args, PREFIX_MEETING_DATE, PREFIX_MEETING_TIME, PREFIX_CANCEL_MEETING);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_MEETING_DATE, PREFIX_MEETING_TIME)) {
+        boolean isClearPresent = arePrefixesPresent(argMultimap, PREFIX_CANCEL_MEETING);
+        boolean isDatePresent = arePrefixesPresent(argMultimap, PREFIX_MEETING_DATE);
+        boolean isTimePresent = arePrefixesPresent(argMultimap, PREFIX_MEETING_TIME);
+
+        if (isClearPresent && (isDatePresent || isTimePresent)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MeetCommand.MESSAGE_USAGE));
+        }
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_MEETING_DATE, PREFIX_MEETING_TIME)
+                && !isClearPresent) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MeetCommand.MESSAGE_USAGE));
         }
 
@@ -40,10 +50,16 @@ public class MeetCommandParser implements Parser<MeetCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MeetCommand.MESSAGE_USAGE), pe);
         }
 
-        MeetingDate date = ParserUtil.parseMeetingDate(argMultimap.getValue(PREFIX_MEETING_DATE).get());
-        MeetingTime time = ParserUtil.parseMeetingTime(argMultimap.getValue(PREFIX_MEETING_TIME).get());
+        ScheduledMeeting newMeeting;
 
-        ScheduledMeeting newMeeting = new ScheduledMeeting(date, time);
+        if (isClearPresent) {
+            newMeeting = new ScheduledMeeting();
+        } else {
+            MeetingDate date = ParserUtil.parseMeetingDate(argMultimap.getValue(PREFIX_MEETING_DATE).get());
+            MeetingTime time = ParserUtil.parseMeetingTime(argMultimap.getValue(PREFIX_MEETING_TIME).get());
+            newMeeting = new ScheduledMeeting(date, time);
+        }
+
         return new MeetCommand(name, newMeeting);
     }
 

--- a/src/main/java/seedu/address/model/person/MeetingDate.java
+++ b/src/main/java/seedu/address/model/person/MeetingDate.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 public class MeetingDate {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Meeting should only contain numbers and hyphens, in the format of YYYY-MM-DD";
+            "Meeting date should only contain numbers and hyphens, in the format of YYYY-MM-DD";
     public static final String VALIDATION_REGEX = "^([0-9]{4})(-)(0[1-9]|1[0-2])(-)(0[1-9]|1[0-9]|2[0-9]|3[0-1])$";
     public final LocalDate value;
 

--- a/src/main/java/seedu/address/model/person/MeetingTime.java
+++ b/src/main/java/seedu/address/model/person/MeetingTime.java
@@ -14,8 +14,8 @@ public class MeetingTime {
     public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("HHmm");
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Meeting should only contain numbers and hyphens, in the format of YYYY-MM-DD";
-    //public static final String VALIDATION_REGEX = "^([0-9]{4})(-)(0[1-9]|1[0-2])(-)(0[1-9]|1[0-9]|2[0-9]|3[0-1])$";
+            "Meeting time should only contain numbers, in the 24hr format of HHmm";
+    public static final String VALIDATION_REGEX = "^(0[0-9]|1[0-9]|2[0-3])([0-5][0-9])$";
     public final LocalTime value;
 
     /**
@@ -33,8 +33,7 @@ public class MeetingTime {
      * Returns true if a given string is a valid time.
      */
     public static boolean isValidTime(String test) {
-        return true;
-        // return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -66,10 +66,17 @@ public class PersonCard extends UiPart<Region> {
         prevDateMet.setText("Last met: " + person.getPrevDateMet().value.toString());
         salary.setText("Salary: $" + person.getSalary().value);
         info.setText("Info: " + person.getInfo().value);
-        String[] meetingSplit = person.getScheduledMeeting().toString().split(" ");
-        String meetingDate = meetingSplit[0];
-        String meetingTime = meetingSplit[1];
-        scheduledMeeting.setText("Scheduled meeting: " + meetingDate + " at " + meetingTime);
+
+        String meetingDetails = person.getScheduledMeeting().toString();
+        if (meetingDetails.equals("No meeting scheduled")) {
+            scheduledMeeting.setText(meetingDetails);
+        } else {
+            String[] meetingSplit = person.getScheduledMeeting().toString().split(" ");
+            String meetingDate = meetingSplit[0];
+            String meetingTime = meetingSplit[1];
+            scheduledMeeting.setText("Scheduled meeting: " + meetingDate + " at " + meetingTime);
+        }
+
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));


### PR DESCRIPTION
Meet command should be able to handle a way to clear
scheduled meeting with clients.
Displaying no scheduled meeting was also not working as intended.

Let's
* add a prefix c/ to clear meetings for client.
* add proper regular expression check for 24hr format time input.
* bugfix to display no scheduled meeting properly.

Note:
To clear scheduled meeting: meet NAME c/
Added checks to ensure c/ does not appear with d/ or t/ and vice versa.

Should close #87 and close #83.