### PR TITLE
Changes to delete command and the way Hustlebook finds clients

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -7,7 +7,6 @@ import java.util.List;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.HustleBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -36,8 +35,7 @@ public class DeleteCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
-        HustleBook tempHustleBook = new HustleBook();
-        Index targetIndex = tempHustleBook.getPersonListIndex(lastShownList, targetName);
+        Index targetIndex = model.getPersonListIndex(targetName);
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Arrays;
 import java.util.function.Predicate;

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,14 +1,18 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import java.util.List;
+import java.util.Arrays;
+import java.util.function.Predicate;
 
+import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 
 /**
@@ -24,18 +28,45 @@ public class DeleteCommand extends Command {
             + "Example: " + COMMAND_WORD + " John Doe";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_MULTIPLE_PERSON = "More than 1 person exists with that name. Please look at the "
+            + "list below and enter the index of the client you wish to delete \n"
+            + "Example: 1, 2, 3 ...";
 
     private final Name targetName;
+    private final String targetNameStr;
+    private int index = 0;
 
+
+    /**
+     * @param targetName name of the person in the filtered person list to delete
+     */
     public DeleteCommand(Name targetName) {
+        requireNonNull(targetName);
+
         this.targetName = targetName;
+        this.targetNameStr = targetName.fullName;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
-        Index targetIndex = model.getPersonListIndex(targetName);
+        // Copied code
+        FilteredList<Person> lastShownList = (FilteredList<Person>) model.getFilteredPersonList();
+        Index targetIndex;
+        if (index == 0) {
+            FilteredList<Person> tempList = new FilteredList<Person>(lastShownList);
+            String[] nameKeywords = targetNameStr.split("\\s+");
+            Predicate<Person> predicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
+            tempList.setPredicate(predicate);
+
+            if (tempList.size() > 1) {
+                lastShownList.setPredicate(predicate);
+                return new CommandResult(MESSAGE_MULTIPLE_PERSON);
+            }
+            targetIndex = model.getPersonListIndex(targetName);
+        } else {
+            targetIndex = Index.fromOneBased(index);
+        }
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
@@ -43,7 +74,12 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
+
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -55,7 +55,7 @@ public class DeleteCommand extends Command {
         Index targetIndex;
         if (index == 0) {
             FilteredList<Person> tempList = new FilteredList<Person>(lastShownList);
-            String[] nameKeywords = targetNameStr.split("\\s+");
+            String[] nameKeywords = {targetNameStr};
             Predicate<Person> predicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
             tempList.setPredicate(predicate);
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -24,7 +24,6 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.HustleBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -108,8 +107,7 @@ public class EditCommand extends Command {
                 return new CommandResult(MESSAGE_MULTIPLE_PERSON);
             }
 
-            HustleBook tempHustleBook = new HustleBook();
-            targetIndex = tempHustleBook.getPersonListIndex(lastShownList, targetName);
+            targetIndex = model.getPersonListIndex(targetName);
         } else {
             targetIndex = Index.fromOneBased(index);
         }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -98,7 +98,7 @@ public class EditCommand extends Command {
         Index targetIndex;
         if (index == 0) {
             FilteredList<Person> tempList = new FilteredList<Person>(lastShownList);
-            String[] nameKeywords = targetNameStr.split("\\s+");
+            String[] nameKeywords = {targetNameStr};
             Predicate<Person> predicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
             tempList.setPredicate(predicate);
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -16,8 +16,9 @@ public class FindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Separate names by commas (,)"
+            + "Parameters: KEYWORD, [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " alice, bob, charlie";
 
     private final NameContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/FlagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FlagCommand.java
@@ -8,7 +8,6 @@ import java.util.List;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.HustleBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.Flag;
 import seedu.address.model.person.Name;
@@ -45,8 +44,7 @@ public class FlagCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
-        HustleBook tempHustleBook = new HustleBook();
-        Index targetIndex = tempHustleBook.getPersonListIndex(lastShownList, targetName);
+        Index targetIndex = model.getPersonListIndex(targetName);
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/MeetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MeetCommand.java
@@ -8,7 +8,6 @@ import java.util.List;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.HustleBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -41,8 +40,7 @@ public class MeetCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
-        HustleBook tempHustleBook = new HustleBook();
-        Index targetIndex = tempHustleBook.getPersonListIndex(lastShownList, targetName);
+        Index targetIndex = model.getPersonListIndex(targetName);
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -25,7 +25,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split(", ");
+        String[] nameKeywords = trimmedArgs.split(",\\s+");
 
         return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -25,7 +25,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        String[] nameKeywords = trimmedArgs.split(", ");
 
         return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }

--- a/src/main/java/seedu/address/logic/parser/NumberParser.java
+++ b/src/main/java/seedu/address/logic/parser/NumberParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -35,6 +36,10 @@ public class NumberParser {
     public Command parse() throws ParseException {
         if (lastCommand instanceof EditCommand) {
             EditCommand newCommand = (EditCommand) lastCommand;
+            newCommand.setIndex(index);
+            return newCommand;
+        } else if (lastCommand instanceof DeleteCommand) {
+            DeleteCommand newCommand = (DeleteCommand) lastCommand;
             newCommand.setIndex(index);
             return newCommand;
         } else {

--- a/src/main/java/seedu/address/model/HustleBook.java
+++ b/src/main/java/seedu/address/model/HustleBook.java
@@ -5,10 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import javafx.collections.ObservableList;
-import seedu.address.commons.core.index.Index;
-import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.Flag;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ScheduledMeeting;
 import seedu.address.model.person.UniquePersonList;
@@ -126,29 +123,6 @@ public class HustleBook implements ReadOnlyHustleBook {
     }
 
     //// util methods
-
-    /**
-     * Gives the index of the person with the given name if they exist.
-     * If person doesn't exist, final index value is saved as length of the list.
-     * @param personList A list of person objects stored in data.
-     * @param name The given name used as reference to find the person.
-     * @return An Index object holding the index of the person in the list.
-     */
-    public Index getPersonListIndex(List<Person> personList, Name name) {
-        Index result = Index.fromZeroBased(0);
-        String[] personName = name.fullName.split(" ");
-        personLoop:
-        for (Person i : personList) {
-            String currName = i.getName().fullName;
-            for (String word : personName) {
-                if (StringUtil.containsWordIgnoreCase(currName, word)) {
-                    break personLoop;
-                }
-            }
-            result.increment(1);
-        }
-        return result;
-    }
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,7 +5,9 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.person.Flag;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ScheduledMeeting;
 
@@ -96,7 +98,7 @@ public interface Model {
      */
     void sortPersonListByDate();
 
-    /** Returns an unmodifiable view of the filtered person list */
+    /** Returns an unmodifiable view of the filtered person list. */
     ObservableList<Person> getFilteredPersonList();
 
     /**
@@ -104,4 +106,9 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Returns the index of a specified person in the filtered person list.
+     */
+    Index getPersonListIndex(Name name);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -151,14 +151,11 @@ public class ModelManager implements Model {
     @Override
     public Index getPersonListIndex(Name name) {
         Index result = Index.fromZeroBased(0);
-        String[] personName = name.fullName.split(" ");
-        personLoop:
+        String personName = name.fullName;
         for (Person i : filteredPersons) {
             String currName = i.getName().fullName;
-            for (String word : personName) {
-                if (StringUtil.containsWordIgnoreCase(currName, word)) {
-                    break personLoop;
-                }
+            if (currName.toLowerCase().contains(personName.toLowerCase())) {
+                break;
             }
             result.increment(1);
         }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,7 +12,6 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.Flag;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,7 +11,10 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.Flag;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ScheduledMeeting;
 
@@ -143,6 +146,23 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public Index getPersonListIndex(Name name) {
+        Index result = Index.fromZeroBased(0);
+        String[] personName = name.fullName.split(" ");
+        personLoop:
+        for (Person i : filteredPersons) {
+            String currName = i.getName().fullName;
+            for (String word : personName) {
+                if (StringUtil.containsWordIgnoreCase(currName, word)) {
+                    break personLoop;
+                }
+            }
+            result.increment(1);
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -1,6 +1,7 @@
 package seedu.address.model.person;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
@@ -18,7 +19,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> person.getName().fullName.toLowerCase().contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -1,10 +1,7 @@
 package seedu.address.model.person;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.function.Predicate;
-
-import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -15,12 +15,14 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.HustleBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyHustleBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Flag;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ScheduledMeeting;
 import seedu.address.testutil.PersonBuilder;
@@ -164,6 +166,12 @@ public class AddCommandTest {
         public void sortPersonListByDate() {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public Index getPersonListIndex(Name name) {
+            throw new AssertionError("This method should not be called.");
+        }
+
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -25,10 +25,10 @@ public class FindCommandParserTest {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        assertParseSuccess(parser, "Alice, Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, " \n Alice, \n \t Bob  \t", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/HustleBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HustleBookParserTest.java
@@ -74,7 +74,7 @@ public class HustleBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")), lastCommand);
+                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(", ")), lastCommand);
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 


### PR DESCRIPTION
Currently delete command deletes the first client whose name matches the given search term. This causes problems as users currenly are not able to delete the clients that are not first in the list.


There are also bugs in the way Hustlebook finds clients. If the user gives the full name of a client, only one client should match, not others with similar names.

Example: If Hustlebook contains "David Li" and "David Tan", the command `find david tan` should only show "David Tan" but not both of them
This applies to `edit` and `delete` as well.

Let's

 - Change the way clients with names matching the search term are detected in `delete`

 - Allow users to input a number to indicate the index of the client they wish to edit
 - Add logic to allow HustleBook to execute the right command when given a number as an input by checking against 
lastCommand
 - Change the way Hustlebook finds clients by matching the full search term instead of one at a time
 - Change the way `find` works by asking users to seperate different names by commas
 
Tests for this new functionality will be added at a later date

This closes #116 , closes #115, closes #114 