### PR TITLE
Update GUI to display salary

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -1,10 +1,8 @@
 package seedu.address.ui;
 
 import java.util.Comparator;
-import java.util.concurrent.Flow;
 
 import javafx.fxml.FXML;
-import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -1,8 +1,10 @@
 package seedu.address.ui;
 
 import java.util.Comparator;
+import java.util.concurrent.Flow;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
@@ -45,7 +47,7 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label prevDateMet;
     @FXML
-    private Label salary;
+    private FlowPane salary;
     @FXML
     private Label info;
     @FXML
@@ -64,7 +66,6 @@ public class PersonCard extends UiPart<Region> {
         email.setText("Email: " + person.getEmail().value);
         flag.setText("Flag: " + person.getFlag().toString());
         prevDateMet.setText("Last met: " + person.getPrevDateMet().value.toString());
-        salary.setText("Salary: $" + person.getSalary().value);
         info.setText("Info: " + person.getInfo().value);
 
         String meetingDetails = person.getScheduledMeeting().toString();
@@ -76,6 +77,8 @@ public class PersonCard extends UiPart<Region> {
             String meetingTime = meetingSplit[1];
             scheduledMeeting.setText("Scheduled meeting: " + meetingDate + " at " + meetingTime);
         }
+
+        salary.getChildren().add(new Label("Salary: $" + person.getSalary().value));
 
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -6,6 +6,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Person;
 
@@ -45,7 +46,7 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label prevDateMet;
     @FXML
-    private FlowPane salary;
+    private Pane salary;
     @FXML
     private Label info;
     @FXML

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -348,5 +348,19 @@
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
     -fx-background-radius: 2;
-    -fx-font-size: 11;
+    -fx-font-size: 12;
+}
+
+#salary {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#salary .label {
+    -fx-text-fill: white;
+    -fx-background-color: #6bd16b;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 12;
 }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -7,35 +7,43 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
-        <Insets top="5" right="5" bottom="5" left="15" />
+        <Insets bottom="5" left="15" right="5" top="5" />
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
+      <HBox alignment="CENTER_LEFT" spacing="5">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
       </HBox>
-      <FlowPane fx:id="tags" />
+         <FlowPane fx:id="parentFlowPane">
+            <children>
+            <FlowPane fx:id="salary" prefWrapLength="100" />
+            <FlowPane fx:id="tags" />
+            </children>
+         </FlowPane>
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="prevDateMet" styleClass="cell_small_label" text="\$prevDateMet" />
-      <Label fx:id="salary" styleClass="cell_small_label" text="\$salary" />
       <Label fx:id="info" styleClass="cell_small_label" text="\$info" />
       <Label fx:id="flag" styleClass="cell_small_label" text="\$flag" />
       <Label fx:id="scheduledMeeting" styleClass="cell_small_label" text="\$scheduledMeeting" />
     </VBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -6,11 +6,12 @@
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
@@ -30,7 +31,10 @@
       </HBox>
          <FlowPane fx:id="parentFlowPane">
             <children>
-            <FlowPane fx:id="salary" prefWrapLength="100" />
+            <Pane fx:id="salary">
+                  <FlowPane.margin>
+                     <Insets right="7" />
+                  </FlowPane.margin></Pane>
             <FlowPane fx:id="tags" />
             </children>
          </FlowPane>


### PR DESCRIPTION
Salary: Modify the GUI to better display this attribute.

Currently, the salary attribute is combined with the other attributes when being displayed. This results in the client's information section being clustered.

This update modified the GUI to display the salary attribute as a Flowpane with a green background, making it easier to identify the salary attribute.

Closes #121 