### PR TITLE
Update GUI display of last date met and upcoming meeting attribute

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -63,7 +63,7 @@ public class PersonCard extends UiPart<Region> {
         address.setText("Address: " + person.getAddress().value);
         email.setText("Email: " + person.getEmail().value);
         flag.setText("Flag: " + person.getFlag().toString());
-        prevDateMet.setText("Last met: " + person.getPrevDateMet().value.toString());
+        prevDateMet.setText("Date last met:\n" + person.getPrevDateMet().value.toString());
         salary.setText("Salary: $" + person.getSalary().value);
         info.setText("Info: " + person.getInfo().value);
 
@@ -74,7 +74,7 @@ public class PersonCard extends UiPart<Region> {
             String[] meetingSplit = person.getScheduledMeeting().toString().split(" ");
             String meetingDate = meetingSplit[0];
             String meetingTime = meetingSplit[1];
-            scheduledMeeting.setText("Scheduled meeting: " + meetingDate + " at " + meetingTime);
+            scheduledMeeting.setText("Upcoming meeting:\n" + meetingDate + " at " + meetingTime);
         }
 
         person.getTags().stream()

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -65,7 +65,6 @@ public class PersonCard extends UiPart<Region> {
         email.setText("Email: " + person.getEmail().value);
         flag.setText("Flag: " + person.getFlag().toString());
         prevDateMet.setText("Date last met:\n" + person.getPrevDateMet().value.toString());
-        salary.setText("Salary: $" + person.getSalary().value);
         info.setText("Info: " + person.getInfo().value);
 
         String meetingDetails = person.getScheduledMeeting().toString();

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -350,3 +350,13 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
 }
+
+.cell-date-label {
+    -fx-text-fill: red;
+    -fx-text-alignment: center;
+    -fx-font-family: "Segoe UI";
+    -fx-font-size: 13px;
+    -fx-padding: 4 6 4 6;
+    -fx-border-color: #a0d6b4;
+    -fx-border-radius: 4;
+}

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -6,36 +6,59 @@
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
-        <Insets top="5" right="5" bottom="5" left="15" />
+        <Insets bottom="5" left="15" right="5" top="5" />
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
+      <HBox alignment="CENTER_LEFT" spacing="5">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <Label fx:id="prevDateMet" styleClass="cell_small_label" text="\$prevDateMet" />
       <Label fx:id="salary" styleClass="cell_small_label" text="\$salary" />
       <Label fx:id="info" styleClass="cell_small_label" text="\$info" />
       <Label fx:id="flag" styleClass="cell_small_label" text="\$flag" />
-      <Label fx:id="scheduledMeeting" styleClass="cell_small_label" text="\$scheduledMeeting" />
     </VBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
   </GridPane>
+   <FlowPane fx:id="meetingBox" alignment="CENTER">
+      <children>
+         <Pane fx:id="prevDateBox">
+            <children>
+            <Label fx:id="prevDateMet" styleClass="cell-date-label" text="\$prevDateMet" />
+            </children>
+            <FlowPane.margin>
+               <Insets right="20.0" />
+            </FlowPane.margin>
+         </Pane>
+         <Pane fx:id="nextMeetingBox">
+            <children>
+            <Label fx:id="scheduledMeeting" styleClass="cell-date-label" text="\$scheduledMeeting" />
+            </children>
+            <FlowPane.margin>
+               <Insets left="20.0" />
+            </FlowPane.margin>
+         </Pane>
+      </children>
+   </FlowPane>
 </HBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -35,14 +35,12 @@
                   <FlowPane.margin>
                      <Insets right="7" />
                   </FlowPane.margin></Pane>
-            <FlowPane fx:id="tags" />
+            <FlowPane fx:id="tags" prefWrapLength="200" />
             </children>
          </FlowPane>
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <Label fx:id="salary" styleClass="cell_small_label" text="\$salary" />
-      <Label fx:id="prevDateMet" styleClass="cell_small_label" text="\$prevDateMet" />
       <Label fx:id="info" styleClass="cell_small_label" text="\$info" />
       <Label fx:id="flag" styleClass="cell_small_label" text="\$flag" />
     </VBox>


### PR DESCRIPTION
Meeting (`Last date met` and `Upcoming meeting` attribute): Modify the GUI to better display this attribute.

Currently, the last date met and the upcoming meeting attribute is displayed together with other attributes. This results in a long and messy organization of client information.

This update modified the GUI to display the last date met attribute and upcoming meeting attribute separately from the other attributes.

Closes #122, closes #123 