### PR TITLE
Prevent meeting clashes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MeetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MeetCommand.java
@@ -23,6 +23,7 @@ public class MeetCommand extends Command {
             + "Parameters: NAME (must be found in HustleBook), DATE (YYYY-MM-DD format), TIME (24HR Format)\n"
             + "Example: " + COMMAND_WORD + " NAME" + " m/2022-02-23" + " t/1530";
 
+    public static final String MESSAGE_MEETING_CLASH = "A meeting clash is detected!";
     public static final String MESSAGE_SCHEDULE_MEETING_PERSON_SUCCESS = "Updated a meeting with %1$s";
 
     private final Name targetName;
@@ -40,6 +41,11 @@ public class MeetCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (model.hasSameMeeting(scheduledMeeting)) {
+            throw new CommandException(MeetCommand.MESSAGE_MEETING_CLASH);
+        }
+
         List<Person> lastShownList = model.getFilteredPersonList();
         HustleBook tempHustleBook = new HustleBook();
         Index targetIndex = tempHustleBook.getPersonListIndex(lastShownList, targetName);

--- a/src/main/java/seedu/address/model/HustleBook.java
+++ b/src/main/java/seedu/address/model/HustleBook.java
@@ -101,6 +101,17 @@ public class HustleBook implements ReadOnlyHustleBook {
     }
 
     /**
+     * Returns true if any person with the same scheduled meeting
+     * as {@code scheduledMeeting} exists in the hustle book.
+     * @param scheduledMeeting The meeting to be scheduled.
+     * @return true if meeting clashes.
+     */
+    public boolean hasSameMeeting(ScheduledMeeting scheduledMeeting) {
+        requireNonNull(scheduledMeeting);
+        return persons.anyMeetingClash(scheduledMeeting);
+    }
+
+    /**
      * Schedules a meeting date and time with the targetted person.
      * @param target The person to be scheduled a meeting with.
      * @param scheduledMeeting The meeting details.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -61,6 +61,13 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
+     * Returns true if a meeting clashes with existing ones in the hustle book.
+     * @param scheduledMeeting Meeting to be scheduled.
+     * @return true if meeting clashes.
+     */
+    boolean hasSameMeeting(ScheduledMeeting scheduledMeeting);
+
+    /**
      * Deletes the given person.
      * The person must exist in the hustle book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -112,6 +112,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasSameMeeting(ScheduledMeeting scheduledMeeting) {
+        requireNonNull(scheduledMeeting);
+        return hustleBook.hasSameMeeting(scheduledMeeting);
+    }
+
+    @Override
     public void addPerson(Person person) {
         hustleBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -153,6 +153,20 @@ public class Person {
     }
 
     /**
+     * Returns true if current person has the same scheduled meeting.
+     * @param scheduledMeeting The meeting to be compared with.
+     * @return true if meeting clash.
+     */
+    public boolean hasSameMeeting(ScheduledMeeting scheduledMeeting) {
+        if (scheduledMeeting == getScheduledMeeting()) {
+            return true;
+        }
+
+        return scheduledMeeting != null
+                && scheduledMeeting.hasSameMeeting(getScheduledMeeting());
+    }
+
+    /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
      */

--- a/src/main/java/seedu/address/model/person/ScheduledMeeting.java
+++ b/src/main/java/seedu/address/model/person/ScheduledMeeting.java
@@ -53,13 +53,19 @@ public class ScheduledMeeting {
      * @param otherMeeting The other meeting to check against.
      * @return true if this meeting has the same date and time as the other meeting.
      */
-    public boolean isSameMeeting(ScheduledMeeting otherMeeting) {
+    public boolean hasSameMeeting(ScheduledMeeting otherMeeting) {
         if (otherMeeting == this) {
             return true;
         }
 
-        return otherMeeting != null
-                && otherMeeting.equals(this);
+        if (otherMeeting != null
+                && otherMeeting.hasMeetingScheduled()
+                && this.hasMeetingScheduled()) {
+            return otherMeeting.getDate().equals(getDate())
+                    && otherMeeting.getTime().equals(getTime());
+        } else {
+            return false;
+        }
     }
 
     @Override
@@ -73,13 +79,15 @@ public class ScheduledMeeting {
         }
 
         ScheduledMeeting otherMeeting = (ScheduledMeeting) other;
-        // Check if both does not have any scheduled meetings
-        if (!otherMeeting.hasMeetingScheduled() && !this.hasMeetingScheduled()) {
-            return true;
+        // Compare both date and time only if both has scheduled meetings
+        if (otherMeeting.hasMeetingScheduled() && this.hasMeetingScheduled()) {
+            return otherMeeting.getDate().equals(getDate())
+                    && otherMeeting.getTime().equals(getTime());
+        } else if (!otherMeeting.hasMeetingScheduled() && !this.hasMeetingScheduled()) {
+            return true; // Return true if both have no meeting scheduled
+        } else {
+            return false;
         }
-
-        return otherMeeting.getDate().equals(getDate())
-                && otherMeeting.getTime().equals(getTime());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -39,6 +39,18 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Returns true if any person with the same scheduled meeting
+     * as {@code scheduledMeeting} exists in the hustle book.
+     * @param scheduledMeeting The meeting to be scheduled.
+     * @return true if meeting clashes.
+     */
+    public boolean anyMeetingClash(ScheduledMeeting scheduledMeeting) {
+        requireNonNull(scheduledMeeting);
+        return internalList.stream()
+                .anyMatch(person -> person.hasSameMeeting(scheduledMeeting));
+    }
+
+    /**
      * Adds a person to the list.
      * The person must not already exist in the list.
      */

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -147,6 +147,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasSameMeeting(ScheduledMeeting scheduledMeeting) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setPerson(Person target, Person editedPerson) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Meetings could be scheduled to the same date and time as existing
meetings which should not occur. Add a check whenever user schedules
a meeting that compares with the existing meetings.

This should close #88.

Let's add a check to ensure meetings that are scheduled
does not clash with existing ones.