### PR TITLE
Update user guide URL in the help window

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -24,7 +24,7 @@ import seedu.address.logic.commands.ListCommand;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://ay2122s2-cs2103t-w15-2.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL + "\n\n"
             + AddCommand.MESSAGE_USAGE + "\n\n"
             + ClearCommand.MESSAGE_USAGE + "\n\n"


### PR DESCRIPTION
Currently, the user guide link directs users to the old AB3 user guide webpage.

This update modified the link to the direct users to the Hustlebook user guide webpage.

Closes #127 