### PR TITLE
Fix bug with salary attribute

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -55,7 +55,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         PrevDateMet prevDateMet = ParserUtil.parsePrevDateMet(argMultimap.getValue(PREFIX_PREV_DATE_MET)
                 .orElse(PrevDateMet.getTodaysDate()));
-        Salary salary = ParserUtil.parseSalary(argMultimap.getValue(PREFIX_SALARY).get());
+        Salary salary = ParserUtil.parseSalary(argMultimap.getValue(PREFIX_SALARY).orElse(Salary.DEFAULT_VALUE));
         Info info = ParserUtil.parseInfo(argMultimap.getValue(PREFIX_INFO)
                 .orElse("No further info"));
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -36,7 +36,7 @@ public class Person {
      */
     public Person(Name name, Phone phone, Email email, Address address, Flag flag, Set<Tag> tags,
                   PrevDateMet prevDateMet, Salary salary, Info info, ScheduledMeeting scheduledMeeting) {
-        requireAllNonNull(name, phone, email, address, tags, prevDateMet, info, scheduledMeeting);
+        requireAllNonNull(name, phone, email, address, flag, tags, prevDateMet, salary, info, scheduledMeeting);
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -54,7 +54,7 @@ public class Person {
      */
     public Person(Name name, Phone phone, Email email, Address address, Flag flag, Set<Tag> tags,
                   PrevDateMet prevDateMet, Salary salary, Info info) {
-        requireAllNonNull(name, phone, email, address, tags, prevDateMet, info);
+        requireAllNonNull(name, phone, email, address, flag, tags, prevDateMet, salary, info);
         this.name = name;
         this.phone = phone;
         this.email = email;

--- a/src/main/java/seedu/address/model/person/Salary.java
+++ b/src/main/java/seedu/address/model/person/Salary.java
@@ -9,6 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Salary {
 
     public static final String MESSAGE_CONSTRAINTS = "Salary should only contain numbers";
+    public static final String DEFAULT_VALUE = "0";
     private static final String VALIDATION_REGEX = "\\d+";
     public final String value;
 
@@ -27,7 +28,7 @@ public class Salary {
      * Constructs a {@code Salary} with a default value of "0".
      */
     public Salary() {
-        this.value = "0";
+        this.value = DEFAULT_VALUE;
     }
 
     /**


### PR DESCRIPTION
Currently, when adding clients with no salary attribute, HustleBook throws an error.

This update fixed that bug and sets a default value to salary when no salary attribute is provided.

Fixes #144 