### PR TITLE
Add command undo

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -24,6 +24,7 @@ To get started, click on any of the headers in the table of content to jump to t
     * [Editing a client : `edit`](#editing-a-client--edit)
     * [Locating clients by name : `find`](#locating-clients-by-name--find)
     * [Deleting a client : `delete`](#deleting-a-client--delete)
+    * [Undoing the previous commands : `undo`](#undoing-the-previous-commands--undo)
     * [Clearing all entries : `clear`](#clearing-all-entries--clear)
     * [Exiting the program : `exit`](#exiting-the-program--exit)
     * [Saving the data](#saving-the-data)
@@ -279,6 +280,14 @@ Example:
 * Running the command `delete n/John` will show a list of clients with names containing "John"
 * If you wish to delete `John Doe` and he is the first person listed, typing `1` will delete `John Doe`
 
+### Undoing the previous commands : `undo`
+
+Undoes the previous commands executed.
+  * Multiple `undo` is possible. 
+  * Maximum possible `undo` is till the time HustleBook is launched. 
+
+Format: `undo`
+
 ### Clearing all entries : `clear`
 
 Clears all entries from the HustleBook.
@@ -313,10 +322,11 @@ If your changes to the data file makes its format invalid, HustleBook will disca
 | **List**   | `list`                                                                                                                                                                                      |
 | **Clear**  | `clear`                                                                                                                                                                                     |
 | **Sort**   | `sort`                                                                                                                                                                                      |
+| **Undo**  | `undo`                                                                                                                                                                                       |
 | **Delete** | `delete NAME`<br> e.g., `delete John`                                                                                                                                                       |
 | **Flag**   | `flag NAME`<br> e.g., `flag John`                                                                                                                                                           |
 | **Unflag** | `unflag NAME` <br> e.g., `unflag John`                                                                                                                                                      |
 | **Meet**   | `meet NAME d/DATE t/TIME` <br> e.g., `meet John d/2022-05-25 t/1430`                                                                                                                        |
-| **Edit**   | `edit NAME [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [d/DATE] [i/INFO] [t/TAG]…​`<br> e.g.,`edit John n/James Lee e/jameslee@example.com`                                             |
+| **Edit**   | `edit NAME [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [d/DATE] [i/INFO] [t/TAG]…​`<br> e.g.,`edit John n/James Lee e/jameslee@example.com`                                          |
 | **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                                                                                                                  |
 | **Help**   | `help`                                                                                                                                                                                      |

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.HustleBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.HustleBookHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyHustleBook;
 import seedu.address.model.person.Person;
@@ -28,6 +29,7 @@ public class LogicManager implements Logic {
     private final Storage storage;
     private final HustleBookParser hustleBookParser;
     private Command lastCommand;
+    private HustleBookHistory hustleBookHistory;
 
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
@@ -36,6 +38,8 @@ public class LogicManager implements Logic {
         this.model = model;
         this.storage = storage;
         hustleBookParser = new HustleBookParser();
+        hustleBookHistory = HustleBookHistory.getInstance();
+        hustleBookHistory.update(getHustleBook());
     }
 
     @Override
@@ -49,6 +53,10 @@ public class LogicManager implements Logic {
 
         try {
             storage.saveHustleBook(model.getHustleBook());
+            if (!commandText.equals("undo")) {
+                logger.info("Saving previous data state of HustleBook");
+                hustleBookHistory.update(getHustleBook());
+            }
         } catch (IOException ioe) {
             throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
         }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Undoes the data of the HustleBook to the previous state.
+ */
+public class UndoCommand extends Command {
+    public static final String COMMAND_WORD = "undo";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undo the last command";
+    public static final String MESSAGE_UNDO_SUCCESS = "Undo Successful!";
+    public static final String MESSAGE_NO_UNDO = "There are no commands to undo";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        try {
+            model.undoHustleBook();
+        } catch (IndexOutOfBoundsException e) {
+            return new CommandResult(MESSAGE_NO_UNDO);
+        }
+        return new CommandResult(MESSAGE_UNDO_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/HustleBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/HustleBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MeetCommand;
 import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -84,6 +85,9 @@ public class HustleBookParser {
 
         case MeetCommand.COMMAND_WORD:
             return new MeetCommandParser().parse(arguments);
+
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/model/HustleBookHistory.java
+++ b/src/main/java/seedu/address/model/HustleBookHistory.java
@@ -1,0 +1,61 @@
+package seedu.address.model;
+
+import java.util.ArrayList;
+
+/**
+ * Handles the HustleBook history.
+ * Contains data of HustleBook before modification. Uses a Singleton design pattern.
+ */
+public class HustleBookHistory {
+    private static HustleBookHistory hustleBookHistoryObj;
+    private ArrayList<ReadOnlyHustleBook> historyList;
+    private int currStatePointer;
+
+    /**
+     * Constructs the HustleBookHistory Object.
+     */
+    private HustleBookHistory() {
+        historyList = new ArrayList<>();
+        currStatePointer = -1;
+    }
+
+    /**
+     * Allows only one instance of the History obj to be created and used.
+     * @return The single hustleBookHistoryObj instance.
+     */
+    public static HustleBookHistory getInstance() {
+        if (hustleBookHistoryObj == null) {
+            hustleBookHistoryObj = new HustleBookHistory();
+        }
+        return hustleBookHistoryObj;
+    }
+
+    /**
+     * Provides the last data state of the HustleBook.
+     * @return The last data state of the HustleBook.
+     * @throws IndexOutOfBoundsException If no commands left to undo.
+     */
+    public ReadOnlyHustleBook getPrevState() throws IndexOutOfBoundsException {
+        ReadOnlyHustleBook result = historyList.get(currStatePointer - 1);
+        currStatePointer = Math.max(-1, currStatePointer - 1);
+        return result;
+    }
+
+    /**
+     * Updates the History with new updated data state of HustleBook.
+     * @param readOnlyHustleBook The new modified data state of HustleBook.
+     */
+    public void update(ReadOnlyHustleBook readOnlyHustleBook) {
+        ReadOnlyHustleBook cloneBook = new HustleBook(readOnlyHustleBook);
+        currStatePointer++;
+        historyList.add(currStatePointer, cloneBook);
+    }
+
+    /**
+     * Checks if the history is empty.
+     * @return True is history is empty.
+     */
+    public boolean isEmpty() {
+        return historyList.isEmpty();
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -58,6 +58,11 @@ public interface Model {
     ReadOnlyHustleBook getHustleBook();
 
     /**
+     * Undo the HustleBook to the previous state of data
+     */
+    void undoHustleBook();
+
+    /**
      * Returns true if a person with the same identity as {@code person} exists in the hustle book.
      */
     boolean hasPerson(Person person);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -128,13 +128,18 @@ public class ModelManager implements Model {
     @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
-
         hustleBook.setPerson(target, editedPerson);
     }
 
     @Override
     public void sortPersonListBy(Comparator<Person> sortComparator) {
         hustleBook.sortPersonBy(sortComparator);
+    }
+
+    @Override
+    public void undoHustleBook() {
+        ReadOnlyHustleBook prevState = HustleBookHistory.getInstance().getPrevState();
+        this.hustleBook.resetData(prevState);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -129,6 +129,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void undoHustleBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Undo: This allows users to undo the commands executed to go back to a previous state.

Currently, when the user erroneously runs a command, they would have to `edit` or use the respective command again to revert back to the data to the old state. The worst case is when the user accidentally runs the `clear` command, erasing all the data stored. Taking this into consideration, this `undo` command allows users to undo their previously executed commands. 

Let's 
* Add a `undo` class to create and run the `undo` command
* Add a `HustleBookHistory` class to store previous changes to the data in HustleBook
* Update the `logic` class to store any changes to the HustleBook data in the `HustleBookHistory` class
* Update the User Guide to include the `undo` command usage information

Closes #129 