### PR TITLE
Update ListCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -15,7 +15,8 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows updated list of all persons.";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows updated list of all persons.\n"
+            + "Parameters: [flag | unflag]";
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,9 +1,12 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.function.Predicate;
 
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
 
 /**
  * Lists all persons in the hustle book to the user.
@@ -16,11 +19,15 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 
+    private final Predicate<Person> listFilterPredicate;
+    public ListCommand(Predicate<Person> listFilterPredicate) {
+        this.listFilterPredicate = listFilterPredicate;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList(listFilterPredicate);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/HustleBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/HustleBookParser.java
@@ -71,7 +71,7 @@ public class HustleBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -9,18 +9,16 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Person;
 
-
-
 public class ListCommandParser implements Parser<ListCommand> {
 
     public static final Predicate<Person> PREDICATE_SHOW_FLAGGED_PERSONS = person -> person.getFlag().isFlagged;
 
     /**
-     * Parses the given {@code String} of arguments in the context of the SortCommand
-     * and returns a Sort Command object for execution.
+     * Parses the given {@code String} of arguments in the context of the ListCommand
+     * and returns a List Command object for execution.
      *
-     * @param args arguments to be parsed for SortCommand.
-     * @return SortCommand with parsed Comparator.
+     * @param args arguments to be parsed for ListCommand.
+     * @return ListCommand with parsed Predicate.
      * @throws ParseException if the user input does not conform the expected format.
      */
     public ListCommand parse(String args) throws ParseException {
@@ -29,21 +27,20 @@ public class ListCommandParser implements Parser<ListCommand> {
             return new ListCommand(PREDICATE_SHOW_ALL_PERSONS);
         }
 
-        String[] sortVariable = trimmedArgs.split("\\s+");
+        String[] listArgs = trimmedArgs.split("\\s+");
 
-
-        if (sortVariable.length != 1) {
+        if (listArgs.length != 1) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
         }
-        switch(sortVariable[0].toLowerCase()) {
+
+        switch(listArgs[0].toLowerCase()) {
         case "flag":
             return new ListCommand(PREDICATE_SHOW_FLAGGED_PERSONS);
         case "unflag":
             return new ListCommand(PREDICATE_SHOW_FLAGGED_PERSONS.negate());
         default:
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
-
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.function.Predicate;
+
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Person;
+
+
+
+public class ListCommandParser implements Parser<ListCommand> {
+
+    public static final Predicate<Person> PREDICATE_SHOW_FLAGGED_PERSONS = person -> person.getFlag().isFlagged;
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the SortCommand
+     * and returns a Sort Command object for execution.
+     *
+     * @param args arguments to be parsed for SortCommand.
+     * @return SortCommand with parsed Comparator.
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    public ListCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            return new ListCommand(PREDICATE_SHOW_ALL_PERSONS);
+        }
+
+        String[] sortVariable = trimmedArgs.split("\\s+");
+
+
+        if (sortVariable.length != 1) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+        }
+        switch(sortVariable[0].toLowerCase()) {
+        case "flag":
+            return new ListCommand(PREDICATE_SHOW_FLAGGED_PERSONS);
+        case "unflag":
+            return new ListCommand(PREDICATE_SHOW_FLAGGED_PERSONS.negate());
+        default:
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalHustleBook;
 
@@ -28,12 +29,14 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(PREDICATE_SHOW_ALL_PERSONS), model,
+                ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(PREDICATE_SHOW_ALL_PERSONS), model,
+                ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/HustleBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HustleBookParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalNames.FULL_NAME_FIRST_PERSON;
 
@@ -33,7 +34,7 @@ import seedu.address.testutil.PersonUtil;
 public class HustleBookParserTest {
 
     private final HustleBookParser parser = new HustleBookParser();
-    private final Command lastCommand = new ListCommand();
+    private final Command lastCommand = new ListCommand(PREDICATE_SHOW_ALL_PERSONS);
 
     @Test
     public void parseCommand_add() throws Exception {
@@ -88,7 +89,8 @@ public class HustleBookParserTest {
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, lastCommand) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3", lastCommand) instanceof ListCommand);
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE), ()
+            -> parser.parseCommand(ListCommand.COMMAND_WORD + " 3", lastCommand));
     }
 
     @Test


### PR DESCRIPTION
List Command is currently only used to display clients after running find and clients will always only see flagged clients at the top.

Using list with an additional argument will allow users to view all flagged or unflagged clients

Let's
- add a parser for the list command
- let list command take in a Predicate to run updateFilteredPersonList on
- Update the test cases to reflect ParseException thrown with invalid argument