### PR TITLE
Add redo command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -25,6 +25,7 @@ To get started, click on any of the headers in the table of content to jump to t
     * [Locating clients by name : `find`](#locating-clients-by-name--find)
     * [Deleting a client : `delete`](#deleting-a-client--delete)
     * [Undoing the previous commands : `undo`](#undoing-the-previous-commands--undo)
+    * [Redoing the previous commands : `redo`](#redoing-the-previous-commands--redo)
     * [Clearing all entries : `clear`](#clearing-all-entries--clear)
     * [Exiting the program : `exit`](#exiting-the-program--exit)
     * [Saving the data](#saving-the-data)
@@ -288,6 +289,14 @@ Undoes the previous commands executed.
 
 Format: `undo`
 
+### Redoing the previous commands : `redo`
+
+Redoes the previous commands executed.
+  * Multiple `redo` is possible.
+  * Maximum possible `redo` is till the last executed command.
+
+Format: `redo`
+
 ### Clearing all entries : `clear`
 
 Clears all entries from the HustleBook.
@@ -323,6 +332,7 @@ If your changes to the data file makes its format invalid, HustleBook will disca
 | **Clear**  | `clear`                                                                                                                                                                                     |
 | **Sort**   | `sort`                                                                                                                                                                                      |
 | **Undo**  | `undo`                                                                                                                                                                                       |
+| **Redo**   | `redo`                                                                                                                                                                                      |
 | **Delete** | `delete NAME`<br> e.g., `delete John`                                                                                                                                                       |
 | **Flag**   | `flag NAME`<br> e.g., `flag John`                                                                                                                                                           |
 | **Unflag** | `unflag NAME` <br> e.g., `unflag John`                                                                                                                                                      |

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -53,7 +53,7 @@ public class LogicManager implements Logic {
 
         try {
             storage.saveHustleBook(model.getHustleBook());
-            if (!commandText.equals("undo")) {
+            if (!(commandText.equals("undo") || commandText.equals("redo"))) {
                 logger.info("Saving previous data state of HustleBook");
                 hustleBookHistory.update(getHustleBook());
             }

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Redoes the data of the HustleBook to the recent state.
+ */
+public class RedoCommand extends Command {
+    public static final String COMMAND_WORD = "redo";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Redo the last command";
+    public static final String MESSAGE_REDO_SUCCESS = "Redo Successful!";
+    public static final String MESSAGE_NO_REDO = "There are no commands to redo";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        try {
+            model.redoHustleBook();
+        } catch (IndexOutOfBoundsException e) {
+            return new CommandResult(MESSAGE_NO_REDO);
+        }
+        return new CommandResult(MESSAGE_REDO_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/HustleBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/HustleBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FlagCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MeetCommand;
+import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -88,6 +89,9 @@ public class HustleBookParser {
 
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();
+
+        case RedoCommand.COMMAND_WORD:
+            return new RedoCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/model/HustleBookHistory.java
+++ b/src/main/java/seedu/address/model/HustleBookHistory.java
@@ -42,6 +42,18 @@ public class HustleBookHistory {
     }
 
     /**
+     * Provides the recent/next data state of the HustleBook.
+     * @return The recent/next data state of the HustleBook.
+     * @throws IndexOutOfBoundsException If no commands left to redo.
+     */
+    public ReadOnlyHustleBook getNextState() throws IndexOutOfBoundsException,
+            NullPointerException {
+        ReadOnlyHustleBook result = historyList.get(currStatePointer + 1);
+        currStatePointer = Math.min(historyList.size() - 1, currStatePointer + 1);
+        return result;
+    }
+
+    /**
      * Updates the History with new updated data state of HustleBook.
      * @param readOnlyHustleBook The new modified data state of HustleBook.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -62,6 +62,11 @@ public interface Model {
     void undoHustleBook();
 
     /**
+     * Redo the HustleBook data
+     */
+    void redoHustleBook();
+
+    /**
      * Returns true if a person with the same identity as {@code person} exists in the hustle book.
      */
     boolean hasPerson(Person person);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -131,6 +131,12 @@ public class ModelManager implements Model {
         this.hustleBook.resetData(prevState);
     }
 
+    @Override
+    public void redoHustleBook() {
+        ReadOnlyHustleBook nextState = HustleBookHistory.getInstance().getNextState();
+        this.hustleBook.resetData(nextState);
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -133,6 +133,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void redoHustleBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Redo: This allows users to `redo` the commands executed to go back to the next or most recent state.

Currently, when the user erroneously runs the `undo` command, they would have to edit or use the respective command to revert back the data to the intended state. Taking this into consideration, this `redo` command allows users to redo their previously executed commands.

Let's,
* Add `RedoCommand` class to create the redo command object
* Add methods to support getting the next state
* Update the user guide to include the `redo` command usage

Closes #156 