### PR TITLE
Meet and Flag client can handle clients with multiple updates

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MeetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MeetCommand.java
@@ -3,9 +3,11 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import java.util.List;
+import java.util.Arrays;
 import java.util.Set;
+import java.util.function.Predicate;
 
+import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -15,6 +17,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Flag;
 import seedu.address.model.person.Info;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.PrevDateMet;
@@ -30,12 +33,17 @@ public class MeetCommand extends Command {
             + ": Schedule meeting with the person identified by the name used in HustleBook.\n"
             + "Parameters: NAME (must be found in HustleBook), DATE (YYYY-MM-DD format), TIME (24HR Format)\n"
             + "Example: " + COMMAND_WORD + " NAME" + " d/2022-02-23" + " t/1530";
+    public static final String MESSAGE_MULTIPLE_PERSON = "More than 1 person exists with that name. Please look at the "
+            + "list below and enter the index of the client you wish to edit \n"
+            + "Example: 1, 2, 3 ...";
 
     public static final String MESSAGE_MEETING_CLASH = "A meeting clash is detected!";
     public static final String MESSAGE_SCHEDULE_MEETING_PERSON_SUCCESS = "Updated a meeting with %1$s";
 
     private final Name targetName;
+    private final String targetNameStr;
     private final ScheduledMeeting scheduledMeeting;
+    private int index = 0;
 
     /**
      * @param targetName Name of person whose to schedule a meeting with.
@@ -43,6 +51,7 @@ public class MeetCommand extends Command {
      */
     public MeetCommand(Name targetName, ScheduledMeeting scheduledMeeting) {
         this.targetName = targetName;
+        this.targetNameStr = targetName.fullName;
         this.scheduledMeeting = scheduledMeeting;
     }
 
@@ -54,8 +63,23 @@ public class MeetCommand extends Command {
             throw new CommandException(MeetCommand.MESSAGE_MEETING_CLASH);
         }
 
-        List<Person> lastShownList = model.getFilteredPersonList();
-        Index targetIndex = model.getPersonListIndex(targetName);
+        FilteredList<Person> lastShownList = (FilteredList<Person>) model.getFilteredPersonList();
+        Index targetIndex;
+        if (index == 0) {
+            FilteredList<Person> tempList = new FilteredList<Person>((FilteredList<Person>) lastShownList);
+            String[] nameKeywords = {targetNameStr};
+            Predicate<Person> predicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
+            tempList.setPredicate(predicate);
+
+            if (tempList.size() > 1) {
+                lastShownList.setPredicate(predicate);
+                return new CommandResult(MESSAGE_MULTIPLE_PERSON);
+            }
+
+            targetIndex = model.getPersonListIndex(targetName);
+        } else {
+            targetIndex = Index.fromOneBased(index);
+        }
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -66,6 +90,10 @@ public class MeetCommand extends Command {
         model.setPerson(personToScheduleMeeting, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_SCHEDULE_MEETING_PERSON_SUCCESS, personToScheduleMeeting));
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/NumberParser.java
+++ b/src/main/java/seedu/address/logic/parser/NumberParser.java
@@ -2,10 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.MeetCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 
@@ -45,6 +42,10 @@ public class NumberParser implements Parser<Command> {
             return newCommand;
         } else if (lastCommand instanceof MeetCommand) {
             MeetCommand newCommand = (MeetCommand) lastCommand;
+            newCommand.setIndex(index);
+            return newCommand;
+        } else if (lastCommand instanceof FlagCommand) {
+            FlagCommand newCommand = (FlagCommand) lastCommand;
             newCommand.setIndex(index);
             return newCommand;
         } else {

--- a/src/main/java/seedu/address/logic/parser/NumberParser.java
+++ b/src/main/java/seedu/address/logic/parser/NumberParser.java
@@ -2,7 +2,11 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.FlagCommand;
+import seedu.address.logic.commands.MeetCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 

--- a/src/main/java/seedu/address/logic/parser/NumberParser.java
+++ b/src/main/java/seedu/address/logic/parser/NumberParser.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.MeetCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 
@@ -40,6 +41,10 @@ public class NumberParser implements Parser<Command> {
             return newCommand;
         } else if (lastCommand instanceof DeleteCommand) {
             DeleteCommand newCommand = (DeleteCommand) lastCommand;
+            newCommand.setIndex(index);
+            return newCommand;
+        } else if (lastCommand instanceof MeetCommand) {
+            MeetCommand newCommand = (MeetCommand) lastCommand;
             newCommand.setIndex(index);
             return newCommand;
         } else {

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -6,6 +6,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -46,7 +47,9 @@ public class CommandBox extends UiPart<Region> {
         }
 
         try {
-            this.lastCommandStr = commandText;
+            if (!StringUtil.isNonZeroUnsignedInteger(commandText)) {
+                this.lastCommandStr = commandText;
+            }
             commandExecutor.execute(commandText);
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {


### PR DESCRIPTION
Added logic to allow Meet and Flag commands to ask user for clarification when there exists more than 2 users with names that match the given search term

closes #163 

Also updated feature for pressing up arrow on Command Box to display last user input that was not a number

Example:
User runs 
 - `edit John p/123`
 - `1`
Pressing the up arrow will show `edit John p/123` instead of `1`