### PR TITLE
Update UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -187,6 +187,9 @@ Format: `meet NAME d/DATE t/TIME`
 * In the event where more than one name is matches `NAME` input, you would need to specify using `INDEX`
     of the list shown.
 
+Example:
+* `meet John Doe d/2022-03-12 t/1430` Schedules a meeting with client named `John Doe` at 12 March 2022, 2:30pm.
+
 ### Canceling a meeting: `meet`
 
 Schedules a meeting with the `NAME` given of the client with the `DATE` and `TIME` specified.
@@ -197,6 +200,9 @@ Format: `meet NAME c/`
   * If `c/WORDS` is input, eg. `meet John Doe c/abcdef`,HustleBook will still clear the meeting with the given `NAME`.
 * In the event where more than one name is matches `NAME` input, you would need to specify using `INDEX`
   of the list shown.
+
+Example:
+* `meet John Doe c/` Cancels the meeting with client name `John Doe`.
 
 ### Editing a client : `edit`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -119,6 +119,7 @@ A client's data can be added in the future through edit command
 
 * `d/DATE` will be set to today's date by default if not specified.
   * `DATE` has to be in the format **YYYY-MM-DD**.
+  * `DATE` accepts any date (past or future) as long as it is valid. For example, `2022-02-29` is invalid as 2022 is not a leap year.
 * `i/INFO` will be set to `No further info` by default if not specified.
 * `t/TAG` will be empty by default if not specified.
 * `f/FLAG` will be set to `false` by default if not specified.
@@ -181,6 +182,7 @@ The same command can be used to reschedule a meeting with the client.
 Format: `meet NAME d/DATE t/TIME`
 
 * `DATE` input must be in `YYYY-MM-DD` format
+* `DATE` accepts any date (past or future) as long as it is valid. For example, `2022-02-29` is invalid as 2022 is not a leap year.
 * `TIME` input must be in 24-hr format of `HHmm`.
 * In the event where more than one name is matches `NAME` input, you would need to specify using `INDEX`
     of the list shown.


### PR DESCRIPTION
UG did not mention users can type future dates for previous date met
and scheduled meeting dates.

Let's update the UG to state this so that users.