### PR TITLE
Fix usage of flag using add command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FlagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FlagCommandParser.java
@@ -13,10 +13,20 @@ import seedu.address.model.person.Name;
  */
 public class FlagCommandParser implements Parser<FlagCommand> {
 
-    private String commandWord;
+    private String flagInput;
 
     public FlagCommandParser setCommand(String commandWord) {
-        this.commandWord = commandWord;
+        requireNonNull(commandWord);
+        switch (commandWord) {
+        case "flag":
+            this.flagInput = "true";
+            break;
+        case "unflag":
+            this.flagInput = "false";
+            break;
+        default:
+            assert false : "Multiple layers of Switch Case checks have failed";
+        }
         return this;
     }
 
@@ -38,7 +48,7 @@ public class FlagCommandParser implements Parser<FlagCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FlagCommand.MESSAGE_USAGE), pe);
         }
 
-        Flag newFlag = ParserUtil.parseFlag(commandWord);
+        Flag newFlag = ParserUtil.parseFlag(flagInput);
         return new FlagCommand(name, newFlag);
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -108,10 +108,13 @@ public class ParserUtil {
      * Parses a {@code String flag} into an {@code Flag}.
      * Leading and trailing whitespaces will be trimmed.
      */
-    public static Flag parseFlag(String flag) {
+    public static Flag parseFlag(String flag) throws ParseException {
         requireNonNull(flag);
         String trimmedFlag = flag.trim();
-        return new Flag(trimmedFlag.equals("flag"));
+        if (!Flag.isValidFlag(trimmedFlag)) {
+            throw new ParseException(Flag.MESSAGE_CONSTRAINTS);
+        }
+        return new Flag(trimmedFlag);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Flag.java
+++ b/src/main/java/seedu/address/model/person/Flag.java
@@ -1,10 +1,15 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 public class Flag {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Flag should only be 'true' or 'false'.";
     public static final String VALIDATION_REGEX = "(true|false)";
+    public static final String FLAG_INPUT_TRUE = "true";
+    public static final String FLAG_INPUT_FALSE = "false";
     public final boolean isFlagged;
 
     /**
@@ -17,15 +22,17 @@ public class Flag {
     /**
      * Constructs a {@code Flag} with given String boolean.
      *
-     * @param bool If the person is flagged.
+     * @param input Used to flag or unflag person.
      */
-    public Flag(String bool) {
-        if (bool.equalsIgnoreCase("false")) {
+    public Flag(String input) {
+        requireNonNull(input);
+        checkArgument(isValidFlag(input), MESSAGE_CONSTRAINTS);
+        if (input.equals(FLAG_INPUT_FALSE)) {
             isFlagged = false;
-        } else if (bool.equalsIgnoreCase("true")) {
+        } else if (input.equals(FLAG_INPUT_TRUE)) {
             isFlagged = true;
         } else {
-            throw new RuntimeException("invalid bool");
+            throw new RuntimeException("Invalid input");
         }
     }
 
@@ -33,7 +40,7 @@ public class Flag {
      * Returns true if a given string is a valid flag.
      */
     public static boolean isValidFlag(String test) {
-        return test.toLowerCase().matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX);
     }
 
     @Override


### PR DESCRIPTION
`add` command: `\f` doesn't work as intended. 

Currently, all the inputs to the `\f` prefix bypass the checks and result in all clients added having the flag set as `false`.

This update ensures that the inputs to the `\f` are checked and work as intended.

Fixes #167, fixes #205, fixes #208