### PR TITLE
Fix bug in redo command

### DIFF
--- a/src/main/java/seedu/address/model/HustleBookHistory.java
+++ b/src/main/java/seedu/address/model/HustleBookHistory.java
@@ -55,12 +55,19 @@ public class HustleBookHistory {
 
     /**
      * Updates the History with new updated data state of HustleBook.
+     * When HustleBook data is updated, not through undo/redo command and new info is added or existing info modified,
+     * all previously existed possible info that could have been redo will be cleared.
+     * No further redo can be done.
+     *
      * @param readOnlyHustleBook The new modified data state of HustleBook.
      */
     public void update(ReadOnlyHustleBook readOnlyHustleBook) {
         ReadOnlyHustleBook cloneBook = new HustleBook(readOnlyHustleBook);
         currStatePointer++;
         historyList.add(currStatePointer, cloneBook);
+        int size = historyList.size();
+        // Clears all possible future redo by clearing the elements in the sublist
+        historyList.subList(currStatePointer + 1, size).clear();
     }
 
     /**


### PR DESCRIPTION
`redo` command: Misbehaves when `redo` is called after the `undo` command is called and another command is run.

Currently, the `redo` command misbehaves when information is updated/added (running other commands) after an `undo`. In this case, `redo` should not be working as there is nothing to redo.

This update fixes this issue and ensures that redo is not possible once an information update/addition is done not related to the `undo` command.

Fixes #172