### PR TITLE
Fix the way HustleBook parses numbers

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
  */
 public class StringUtil {
 
+    private static String NUMBER_VALIDATION_REGEX = "\\d+(\\.\\d+)?";
     /**
      * Returns true if the {@code sentence} contains the {@code word}.
      *   Ignores case, but a full word match is required.
@@ -75,6 +76,6 @@ public class StringUtil {
      * @return
      */
     public static boolean isNumber(String s) {
-        return s.matches("\\d+(\\.\\d+)?");
+        return s.matches(NUMBER_VALIDATION_REGEX);
     }
 }

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
  */
 public class StringUtil {
 
-    private static String NUMBER_VALIDATION_REGEX = "\\d+(\\.\\d+)?";
+    private static final String NUMBER_VALIDATION_REGEX = "\\d+(\\.\\d+)?";
     /**
      * Returns true if the {@code sentence} contains the {@code word}.
      *   Ignores case, but a full word match is required.
@@ -72,8 +72,6 @@ public class StringUtil {
      * e.g. -1, 0, 1, 2, 3, ...
      * Returns true for +1, +2, +3, for consistency
      * Returns false for any other non-null string input
-     * @param s
-     * @return
      */
     public static boolean isNumber(String s) {
         return s.matches(NUMBER_VALIDATION_REGEX);

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -65,4 +65,16 @@ public class StringUtil {
             return false;
         }
     }
+
+    /**
+     * Returns true if {@code s} represents an integer.
+     * e.g. -1, 0, 1, 2, 3, ...
+     * Returns true for +1, +2, +3, for consistency
+     * Returns false for any other non-null string input
+     * @param s
+     * @return
+     */
+    public static boolean isNumber(String s) {
+        return s.matches("\\d+(\\.\\d+)?");
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -9,6 +9,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -34,6 +35,7 @@ public class DeleteCommand extends Command {
     private final Name targetName;
     private final String targetNameStr;
     private int index = 0;
+    private int listSize;
 
 
     /**
@@ -60,15 +62,16 @@ public class DeleteCommand extends Command {
 
             if (tempList.size() > 1) {
                 lastShownList.setPredicate(predicate);
+                listSize = lastShownList.size();
                 return new CommandResult(MESSAGE_MULTIPLE_PERSON);
             }
+
             targetIndex = model.getPersonListIndex(targetName);
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
+            }
         } else {
             targetIndex = Index.fromOneBased(index);
-        }
-
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
@@ -77,7 +80,10 @@ public class DeleteCommand extends Command {
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }
 
-    public void setIndex(int index) {
+    public void setIndex(int index) throws ParseException {
+        if (index <= 0 || index > listSize) {
+            throw new ParseException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
         this.index = index;
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -23,6 +23,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -71,6 +72,7 @@ public class EditCommand extends Command {
     private final String targetNameStr;
     private final EditPersonDescriptor editPersonDescriptor;
     private int index = 0;
+    private int listSize;
 
     /**
      * @param name name of the person in the filtered person list to edit
@@ -101,16 +103,16 @@ public class EditCommand extends Command {
 
             if (tempList.size() > 1) {
                 lastShownList.setPredicate(predicate);
+                listSize = lastShownList.size();
                 return new CommandResult(MESSAGE_MULTIPLE_PERSON);
             }
 
             targetIndex = model.getPersonListIndex(targetName);
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
+            }
         } else {
             targetIndex = Index.fromOneBased(index);
-        }
-
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
         }
 
         Person personToEdit = lastShownList.get(targetIndex.getZeroBased());
@@ -125,7 +127,10 @@ public class EditCommand extends Command {
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 
-    public void setIndex(int index) {
+    public void setIndex(int index) throws ParseException {
+        if (index <= 0 || index > listSize) {
+            throw new ParseException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
         this.index = index;
     }
 

--- a/src/main/java/seedu/address/logic/commands/FlagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FlagCommand.java
@@ -11,6 +11,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -49,6 +50,7 @@ public class FlagCommand extends Command {
     private final String targetNameStr;
     private final Flag flag;
     private int index = 0;
+    private int listSize;
 
     /**
      * @param targetName Name of person whose flag to replace.
@@ -73,16 +75,20 @@ public class FlagCommand extends Command {
 
             if (tempList.size() > 1) {
                 lastShownList.setPredicate(predicate);
+                listSize = lastShownList.size();
                 return new CommandResult(MESSAGE_MULTIPLE_PERSON);
             }
 
             targetIndex = model.getPersonListIndex(targetName);
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
+            }
         } else {
             targetIndex = Index.fromOneBased(index);
         }
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
         }
         Person personToFlag = lastShownList.get(targetIndex.getZeroBased());
         Person editedPerson = createFlagEditedPerson(personToFlag, flag);
@@ -91,7 +97,10 @@ public class FlagCommand extends Command {
         return new CommandResult(String.format(MESSAGE_FLAG_PERSON_SUCCESS, personToFlag));
     }
 
-    public void setIndex(int index) {
+    public void setIndex(int index) throws ParseException {
+        if (index <= 0 || index > listSize) {
+            throw new ParseException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
         this.index = index;
     }
 

--- a/src/main/java/seedu/address/logic/commands/MeetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MeetCommand.java
@@ -11,6 +11,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -45,6 +46,7 @@ public class MeetCommand extends Command {
     private final String targetNameStr;
     private final ScheduledMeeting scheduledMeeting;
     private int index = 0;
+    private int listSize;
 
     /**
      * @param targetName Name of person whose to schedule a meeting with.
@@ -74,16 +76,16 @@ public class MeetCommand extends Command {
 
             if (tempList.size() > 1) {
                 lastShownList.setPredicate(predicate);
+                listSize = lastShownList.size();
                 return new CommandResult(MESSAGE_MULTIPLE_PERSON);
             }
 
             targetIndex = model.getPersonListIndex(targetName);
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
+            }
         } else {
             targetIndex = Index.fromOneBased(index);
-        }
-
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
         Person personToScheduleMeeting = lastShownList.get(targetIndex.getZeroBased());
@@ -93,7 +95,10 @@ public class MeetCommand extends Command {
         return new CommandResult(String.format(MESSAGE_SCHEDULE_MEETING_PERSON_SUCCESS, personToScheduleMeeting));
     }
 
-    public void setIndex(int index) {
+    public void setIndex(int index) throws ParseException {
+        if (index <= 0 || index > listSize) {
+            throw new ParseException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
         this.index = index;
     }
 

--- a/src/main/java/seedu/address/logic/parser/HustleBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/HustleBookParser.java
@@ -42,7 +42,7 @@ public class HustleBookParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public Command parseCommand(String userInput, Command lastCommand) throws ParseException {
-        if (StringUtil.isNonZeroUnsignedInteger(userInput)) {
+        if (StringUtil.isNumber(userInput)) {
             return new NumberParser(lastCommand).parse(userInput);
         }
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -45,13 +45,12 @@ public class CommandBox extends UiPart<Region> {
         if (commandText.equals("")) {
             return;
         }
-
         try {
-            if (!StringUtil.isNonZeroUnsignedInteger(commandText)) {
-                this.lastCommandStr = commandText;
-            }
             commandExecutor.execute(commandText);
             commandTextField.setText("");
+            if (!StringUtil.isNumber(commandText)) {
+                this.lastCommandStr = commandText;
+            }
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         }


### PR DESCRIPTION
Right now, when the user inputs a number, it will show inconsistent error messages depending on the number they put.

For example, if they run `edit david p/123` and they are asked to give a confirmation of the index of the client to edit, the number "0" will give `Unknown command` as an error message instead of `The person index provided is invalid`. Error messages for wrong index is also inconsistent across `edit`, `delete` `find` and `meet` commands.

Let's,
 - Fix the way HustleBook recognises numbers
 - Fix the logic of the commands to ensure consistent error messages


Closes #209, Closes #195 