### PR TITLE
Fix misbehaviour of long tag and salary

### DIFF
--- a/src/main/java/seedu/address/model/person/Salary.java
+++ b/src/main/java/seedu/address/model/person/Salary.java
@@ -8,7 +8,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Salary {
 
-    public static final String MESSAGE_CONSTRAINTS = "Salary should only contain numbers";
+    public static final String MESSAGE_CONSTRAINTS = "Salary should only contain numbers and at most 15 digits";
     public static final String DEFAULT_VALUE = "0";
     private static final String VALIDATION_REGEX = "\\d+";
     public final String value;
@@ -38,7 +38,7 @@ public class Salary {
      * @return A boolean stating if the string is valid or not.
      */
     public static boolean isValidSalary(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return (test.matches(VALIDATION_REGEX) && test.length() <= 15);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Salary.java
+++ b/src/main/java/seedu/address/model/person/Salary.java
@@ -10,7 +10,7 @@ public class Salary {
 
     public static final String MESSAGE_CONSTRAINTS = "Salary should only contain numbers and at most 15 digits";
     public static final String DEFAULT_VALUE = "0";
-    private static final String VALIDATION_REGEX = "\\d+";
+    private static final String VALIDATION_REGEX = "\\d{1,15}";
     public final String value;
 
     /**
@@ -38,7 +38,7 @@ public class Salary {
      * @return A boolean stating if the string is valid or not.
      */
     public static boolean isValidSalary(String test) {
-        return (test.matches(VALIDATION_REGEX) && test.length() <= 15);
+        return (test.matches(VALIDATION_REGEX));
     }
 
     /**

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and at most 30 characters";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;
@@ -29,7 +29,7 @@ public class Tag {
      * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidTagName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return (test.matches(VALIDATION_REGEX) && test.length() <= 30);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and at most 30 characters";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and at most 25 characters";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;
@@ -29,7 +29,7 @@ public class Tag {
      * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidTagName(String test) {
-        return (test.matches(VALIDATION_REGEX) && test.length() <= 30);
+        return (test.matches(VALIDATION_REGEX) && test.length() <= 25);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -46,8 +46,6 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label prevDateMet;
     @FXML
-    private Pane salary;
-    @FXML
     private Label info;
     @FXML
     private Label scheduledMeeting;
@@ -79,8 +77,10 @@ public class PersonCard extends UiPart<Region> {
             scheduledMeeting.setText("Upcoming meeting:\n" + meetingDate + " at " + meetingTime);
         }
 
-        salary.getChildren().add(new Label("Salary: $" + person.getSalary().value));
-
+        tags.getChildren().add(new Label("Salary: $" + person.getSalary().value));
+        tags.getChildren().get(0).setStyle("-fx-background-color: #6bd16b;"
+                + "-fx-hgap: 7;"
+                + "-fx-vgap: 3;");
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -30,15 +30,7 @@
         </Label>
         <Label fx:id="name" styleClass="cell_big_label" text="\$first" wrapText="true"/>
       </HBox>
-         <FlowPane fx:id="parentFlowPane">
-            <children>
-            <Pane fx:id="salary">
-                  <FlowPane.margin>
-                     <Insets right="7" />
-                  </FlowPane.margin></Pane>
-            <FlowPane fx:id="tags" prefWrapLength="200" />
-            </children>
-         </FlowPane>
+        <FlowPane fx:id="tags" prefWrapLength="200" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" wrapText="true"/>
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" wrapText="true"/>
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" wrapText="true"/>

--- a/src/test/java/seedu/address/model/person/SalaryTest.java
+++ b/src/test/java/seedu/address/model/person/SalaryTest.java
@@ -1,0 +1,39 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class SalaryTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Salary(null));
+    }
+
+    @Test
+    public void constructor_invalidSalary_throwsIllegalArgumentException() {
+        String invalidSalary = "";
+        assertThrows(IllegalArgumentException.class, () -> new Salary(invalidSalary));
+    }
+
+    @Test
+    void isValidSalary() {
+        // null salary
+        assertThrows(NullPointerException.class, () -> Salary.isValidSalary(null));
+
+        // salary with more than 15 digits
+        assertFalse(Salary.isValidSalary("1234567890123456"));
+
+        // salary with 15 digits
+        assertTrue(Salary.isValidSalary("123456789012345"));
+
+        // salary with non digits
+        assertFalse(Salary.isValidSalary("12345ABCD"));
+
+        // salary with special characters
+        assertFalse(Salary.isValidSalary("1234*!"));
+    }
+}

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -1,5 +1,7 @@
 package seedu.address.model.tag;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -21,6 +23,20 @@ public class TagTest {
     public void isValidTagName() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+
+        // tags with more than 25 characters
+        assertFalse(Tag.isValidTagName("1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
+
+        // tags with 25 characters
+        assertTrue(Tag.isValidTagName("1234567890123456789012345"));
+
+        // tag with special characters
+        assertFalse(Tag.isValidTagName("Abc*"));
+
+        // valid tags
+        assertTrue(Tag.isValidTagName("ABCDEF")); // letters only
+        assertTrue(Tag.isValidTagName("124632")); // numbers only
+        assertTrue(Tag.isValidTagName("ABCE124a")); // alphanumeric
     }
 
 }


### PR DESCRIPTION
Long tags and salary causes the text-wrapping behaviour of the 
other labels to malfunction. No test cases were checked for 
salary and tag has a validity check of limited length. 

Bug found: Tags and salary misalign when multiple tags at max length
when GUI is too small. 

Let's 
* Add validation for tag and salary to limit to a reasonable length.
* Add test cases for salary and tag.
* Fix bug causing misalignment of salary and tags when it's all the max
length.

Should fix #168 , fix #176 , fix #177 , fix #179 and fix #183. 
