### PR TITLE
Fix Bug after selecting index from multiple names

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -149,10 +149,24 @@ Flag a client in the HustleBook to mark them as important.
 
 Format: `flag NAME`
 
-* `NAME` input should be a name found in the HustleBook.
-* `NAME` is not case-sensitive.
-* In the event where more than one name is matches `NAME` input, you would need to specify using `INDEX` 
-of the list shown.
+* Flags the client with the specified `NAME`.
+  * `Name` is case-insensitive. e.g. `John` will match `john`.
+  * Only full words will be matched e.g. `Han` will not match `Hans`.
+* If `NAME` matches multiple clients, you will see a list of clients with matching names.
+  * Input the position on the list of the client you wish to edit.
+
+Example:
+
+**Scenario 1**: You have a client named `John Doe`
+
+`flag John Doe` flags client `John Doe` from on HustleBook.
+
+**Scenario 2**: You have clients named `John Doe`, `John Smith` and `John Willams`.
+* Running the command `flag John` will show a list of clients with names containing "John".
+* If you wish to flag `John Doe` and he is the first person listed, typing `1` and `Enter` will flag `John Doe`.
+* Subsequently, you can continue to flag other "John" listed here by typing their indexes and pressing `Enter`.
+* Run `list` to show all clients and stop flagging clients with names containing "John".
+
 
 ### Unflagging a client : `unflag`
 
@@ -160,10 +174,23 @@ Unflag a client in the HustleBook to unmark flagged clients.
 
 Format: `unflag NAME`
 
-* `NAME` input should be a name found in the HustleBook.
-* `NAME` is not case-sensitive.
-* In the event where more than one name is matches `NAME` input, you would need to specify using `INDEX`
-  of the list shown.
+* Unflags the client with the specified `NAME`.
+  * `Name` is case-insensitive. e.g. `John` will match `john`.
+  * Only full words will be matched e.g. `Han` will not match `Hans`.
+* If `NAME` matches multiple clients, you will see a list of clients with matching names.
+  * Input the position on the list of the client you wish to edit.
+
+Example:
+
+**Scenario 1**: You have a client named `John Doe`
+
+`unflag John Doe` unflags client `John Doe` from on HustleBook.
+
+**Scenario 2**: You have clients named `John Doe`, `John Smith` and `John Willams`.
+* Running the command `unflag John` will show a list of clients with names containing "John".
+* If you wish to unflag `John Doe` and he is the first person listed, typing `1` and `Enter` will unflag `John Doe`.
+* Subsequently, you can continue to unflag other "John" listed here by typing their indexes and pressing `Enter`.
+* Run `list` to show all clients and stop flagging clients with names containing "John".
 
 ### Sorting all clients : `sort`
 
@@ -283,10 +310,6 @@ Format: `delete NAME`
 * Deletes the client with the specified `NAME`.
   * `Name` is case-insensitive. e.g. `John` will match `john`.
   * Only full words will be matched e.g. `Han` will not match `Hans`.
-  * Words separated by spaces in `NAME` will be counted as separate names, unless `NAME` fully matches a client's name
-    * Example: `delete John Doe ` will find clients with names containing `John` and `Doe`, unless
-                there exists a client with the name `John Doe`
-  * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`.
 * If `NAME` matches multiple clients, you will see a list of clients with matching names
   * Input the position on the list of the client you wish to edit.
   

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -159,7 +159,7 @@ Example:
 
 **Scenario 1**: You have a client named `John Doe`
 
-`flag John Doe` flags client `John Doe` from on HustleBook.
+`flag John Doe` flags client `John Doe` on HustleBook.
 
 **Scenario 2**: You have clients named `John Doe`, `John Smith` and `John Willams`.
 * Running the command `flag John` will show a list of clients with names containing "John".
@@ -184,7 +184,7 @@ Example:
 
 **Scenario 1**: You have a client named `John Doe`
 
-`unflag John Doe` unflags client `John Doe` from on HustleBook.
+`unflag John Doe` unflags client `John Doe` on HustleBook.
 
 **Scenario 2**: You have clients named `John Doe`, `John Smith` and `John Willams`.
 * Running the command `unflag John` will show a list of clients with names containing "John".

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -9,6 +9,8 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.MeetCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.HustleBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -29,6 +31,7 @@ public class LogicManager implements Logic {
     private final Storage storage;
     private final HustleBookParser hustleBookParser;
     private Command lastCommand;
+    private int commandCount = 0;
     private HustleBookHistory hustleBookHistory;
 
     /**
@@ -49,7 +52,7 @@ public class LogicManager implements Logic {
         CommandResult commandResult;
         Command command = hustleBookParser.parseCommand(commandText, lastCommand);
         commandResult = command.execute(model);
-        lastCommand = command;
+        setLastCommand(command);
 
         try {
             storage.saveHustleBook(model.getHustleBook());
@@ -87,5 +90,18 @@ public class LogicManager implements Logic {
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
+    }
+
+    private void setLastCommand(Command command) {
+        if ((lastCommand instanceof EditCommand || lastCommand instanceof MeetCommand) && lastCommand == command) {
+            commandCount++;
+        } else {
+            commandCount = 0;
+        }
+        if (commandCount >= 1) {
+            lastCommand = null;
+        } else {
+            lastCommand = command;
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FlagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FlagCommand.java
@@ -93,7 +93,6 @@ public class FlagCommand extends Command {
         Person personToFlag = lastShownList.get(targetIndex.getZeroBased());
         Person editedPerson = createFlagEditedPerson(personToFlag, flag);
         model.setPerson(personToFlag, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_FLAG_PERSON_SUCCESS, personToFlag));
     }
 

--- a/src/main/java/seedu/address/logic/commands/FlagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FlagCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Arrays;
 import java.util.Set;


### PR DESCRIPTION
Edit and Meet commands still allow for indexes to be inputted  in the event of multiple names being matched, 
to edit or schedule meetings. 
Delete and flag commands can delete/flag multiple clients and not show full list.

Unintended bugs: Edit and meet should not allow for anymore indexes after the first index is specified.
Intended feature: Flag and delete should allow for multiple clients until `list` is used to display full client list
Updated User guide to reflect this

Close #197 , close #201 , close #204 , close #206 , close #207 , close #239